### PR TITLE
Fix output buffering

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+max_line_length=79
+
+[*.bat]
+indent_style = tab
+end_of_line = crlf
+
+[LICENSE]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab

--- a/linecook/cli.py
+++ b/linecook/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 `linecook` cli to prepare lines of text for easy consumption.
@@ -75,9 +75,11 @@ def run(args):
         return
 
     try:
-        for line in args.text_stream:
-            # Newlines are usually part of the input line so set `end=''`.
-            print(process_text(line), end='')
+        # FIXME: Workaround for Python 2 buffering bug.
+        #        See comments of https://stackoverflow.com/a/7608205/260303
+        for line in iter(args.text_stream.readline, ''):
+            sys.stdout.write(process_text(line))
+            sys.stdout.flush()
     except KeyboardInterrupt:
         pass
 


### PR DESCRIPTION
When using `linecook` output in a bash pipeline, the output wasn't getting flushed properly and appeared to hang. For example:
```
tail -f file-being-continuously-updated.log | linecook | grep matching-text
```
This would appear to hang due to buffered stdin/stdout